### PR TITLE
Stream output by inheriting stdio

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,17 +32,7 @@ class Scriptable {
     runCommand(hookScript) {
         return () => {
             console.log(`Running script: ${hookScript}`);
-
-            try{
-                var output = execSync(hookScript).toString('utf8');
-
-                this.log(output);
-            } catch(error) {
-                this.log(error.stdout.toString());
-                this.log(error.stderr.toString());
-
-                throw error;
-            }
+            execSync(hookScript, {stdio: 'inherit'});
         }
     }
 


### PR DESCRIPTION
Inherit `stdio` instead of piping

Allows output to stream instead of buffering, while also allowing the script to see the TTY and (typically) output in color.

If the script interleaves `stderr` and `stdout` output, this also displays correctly.