### PR TITLE
Variables are not resolved in scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,25 +14,23 @@ class Scriptable {
         this.stdout = process.stdout;
         this.stderr = process.stderr;
 
-        var customs = this.serverless.service.custom;
-        if(!customs || !customs.scriptHooks) {
+        if (!this.getConfig()) {
             return;
         }
 
-        Object.keys(customs.scriptHooks).forEach(function(event) {
-            var hookScript = customs.scriptHooks[event];
+        Object.keys(this.getConfig()).forEach(function (event) {
             this.hooks[event] = this.runScript(event);
         }, this);
     }
 
     getConfig() {
-		return this.serverless.service.custom.scriptHooks;
-	}
+        return this.serverless.service.custom && this.serverless.service.custom.scriptHooks ? this.serverless.service.custom.scriptHooks : null;
+    }
 
     runScript(event) {
         return () => {
             var hookScript = this.getConfig()[event];
-            if(fs.existsSync(hookScript)) {
+            if (fs.existsSync(hookScript)) {
                 return this.runJavascriptFile(hookScript);
             } else {
                 return this.runCommand(hookScript);
@@ -42,7 +40,7 @@ class Scriptable {
 
     runCommand(hookScript) {
         console.log(`Running script: ${hookScript}`);
-        return execSync(hookScript, {stdio: [this.stdin, this.stdout, this.stderr]});
+        return execSync(hookScript, { stdio: [this.stdin, this.stdout, this.stderr] });
     }
 
     runJavascriptFile(scriptFile) {

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ class Scriptable {
     }
 
     runJavascriptFile(scriptFile) {
+        console.log(`Running file: ${scriptFile}`);
         const sandbox = {
             require: require,
             console: console,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,45 +5,64 @@ const Scriptable = require('./../index');
 
 describe('ScriptablePluginTest', () => {
   it('should run command', () => {
-    var scriptable = new Scriptable({ service: {} });
+    var randomString = `current time ${new Date().getTime()}`;
+    var scriptable = new Scriptable(
+      { service: 
+        {custom: {
+          scriptHooks: {
+            test: `echo ${randomString}`}}}});
     scriptable.stdout = tmp.fileSync({prefix: 'stdout-'});
     scriptable.stderr = tmp.fileSync({prefix: 'stderr-'});
 
-    var randomString = `current time ${new Date().getTime()}`;
-    scriptable.runScript(`echo ${randomString}`)();
+    
+    scriptable.runScript("test")();
 
     expect(fs.readFileSync(scriptable.stdout.name, {encoding: 'utf-8'})).string(randomString);
     expect(fs.readFileSync(scriptable.stderr.name, {encoding: 'utf-8'})).equal('');
   });
 
   it('should run command with color', () => {
-    var scriptable = new Scriptable({ service: {} });
+    var scriptable = new Scriptable({ service: 
+        {custom: {
+          scriptHooks: {
+            test: `node examples/test-with-color.js`}}}});
 
-    scriptable.runScript(`node examples/test-with-color.js`)();
+    scriptable.runScript("test")();
   });
 
   it('should run js with color', () => {
-    var scriptable = new Scriptable({ service: {} });
+    var scriptable = new Scriptable({ service: 
+        {custom: {
+          scriptHooks: {
+            test: `examples/test-with-color.js`}}}});
 
-    scriptable.runScript(`examples/test-with-color.js`)();
+    scriptable.runScript("test")();
   });
 
   it('should support color in child process', () => {
-    var serverless = { service: { package: {} } };
-    var scriptable = new Scriptable(serverless);
+        var serverless = { service: { 
+        package: {},
+        custom: {
+          scriptHooks: {
+            test: `examples/check-is-support-colors.js`}}}};
+        var scriptable = new Scriptable(serverless);
 
-    scriptable.runScript(`examples/check-is-support-colors.js`)();
+    scriptable.runScript("test")();
     expect(serverless.supportColorLevel).to.greaterThan(0);
   });
 
   it('should print error message when run command', () => {
-    var scriptable = new Scriptable({ service: {} });
+    var scriptable = new Scriptable({ service: 
+        {custom: {
+          scriptHooks: {
+            does_exist: `echo`}}}});
     scriptable.stdout = tmp.fileSync({prefix: 'stdout-'});
     scriptable.stderr = tmp.fileSync({prefix: 'stderr-'});
 
     try{
-      scriptable.runScript('not-exists')();
+      scriptable.runScript('not_exists')();
     } catch(err) {
+
       expect(fs.readFileSync(scriptable.stderr.name, {encoding: 'utf-8'})).string('/bin/sh');
       expect(fs.readFileSync(scriptable.stderr.name, {encoding: 'utf-8'})).string('not-exists:');
       expect(fs.readFileSync(scriptable.stderr.name, {encoding: 'utf-8'})).string('not found');
@@ -52,15 +71,15 @@ describe('ScriptablePluginTest', () => {
   });
 
   it('should run javascript', () => {
-    var serverless = { service: { package: {} } };
-    var scriptable = new Scriptable(serverless);
-
-    var scriptFile = tmp.fileSync();
-    fs.writeFileSync(scriptFile.name, 'serverless.service.package.artifact = "test.zip";');
-
-    scriptable.runScript(scriptFile.name)();
+        var scriptFile = tmp.fileSync();
+        fs.writeFileSync(scriptFile.name, 'serverless.service.package.artifact = "test.zip";');
+        var serverless = { service: { 
+        package: {},
+        custom: {
+          scriptHooks: {
+            test: scriptFile.name}}}};    var scriptable = new Scriptable(serverless);
+    scriptable.runScript("test")();
 
     expect(serverless.service.package.artifact).to.equal('test.zip');
   });
 });
-


### PR DESCRIPTION
Currently :

```
custom: 
  stage: bananas
  scriptHooks:
    after:deploy:deploy: echo ${self:custom.stage}

```

Will echo `${self:custom.stage}` rather than `bananas` because the binding of the hookScript is in the constructor - it needs to be when the hook is fired in order for the variable to resolve.